### PR TITLE
Add multi-language support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,9 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.13",
         "react-hook-form": "7.49.3",
-        "react-icons": "^5.4.0"
+        "react-icons": "^5.4.0",
+        "i18next": "^23.10.1",
+        "react-i18next": "^13.0.1"
       },
       "devDependencies": {
         "@biomejs/biome": "1.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,9 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",
     "react-hook-form": "7.49.3",
-    "react-icons": "^5.4.0"
+    "react-icons": "^5.4.0",
+    "i18next": "^23.10.1",
+    "react-i18next": "^13.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.1",

--- a/frontend/src/components/Common/LanguageSwitcher.tsx
+++ b/frontend/src/components/Common/LanguageSwitcher.tsx
@@ -1,0 +1,26 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+function LanguageSwitcher() {
+  const { i18n, t } = useTranslation();
+
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+    localStorage.setItem("language", lng);
+  };
+
+  return (
+    <Menu>
+      <MenuButton as={Button} variant="outline" size="sm">
+        {i18n.language.toUpperCase()}
+      </MenuButton>
+      <MenuList>
+        <MenuItem onClick={() => changeLanguage("en")}>{t("language.english")}</MenuItem>
+        <MenuItem onClick={() => changeLanguage("de")}>{t("language.german")}</MenuItem>
+        <MenuItem onClick={() => changeLanguage("ja")}>{t("language.japanese")}</MenuItem>
+      </MenuList>
+    </Menu>
+  );
+}
+
+export default LanguageSwitcher;

--- a/frontend/src/components/Common/Navbar.tsx
+++ b/frontend/src/components/Common/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router"
 
 import Logo from "/assets/images/agentic-crm.svg"
 import UserMenu from "./UserMenu"
+import LanguageSwitcher from "./LanguageSwitcher"
 
 function Navbar() {
   const display = useBreakpointValue({ base: "none", md: "flex" })
@@ -23,6 +24,7 @@ function Navbar() {
         <Image src={Logo} alt="Logo" w="180px" maxW="2xs" px={2} />
       </Link>
       <Flex gap={2} alignItems="center">
+        <LanguageSwitcher />
         <UserMenu />
       </Flex>
     </Flex>

--- a/frontend/src/components/Common/NotFound.tsx
+++ b/frontend/src/components/Common/NotFound.tsx
@@ -1,7 +1,9 @@
 import { Button, Center, Flex, Text } from "@chakra-ui/react"
 import { Link } from "@tanstack/react-router"
+import { useTranslation } from "react-i18next"
 
 const NotFound = () => {
+  const { t } = useTranslation()
   return (
     <>
       <Flex
@@ -23,7 +25,7 @@ const NotFound = () => {
               404
             </Text>
             <Text fontSize="2xl" fontWeight="bold" mb={2}>
-              Oops!
+              {t("notfound.oops")}
             </Text>
           </Flex>
         </Flex>
@@ -35,7 +37,7 @@ const NotFound = () => {
           textAlign="center"
           zIndex={1}
         >
-          The page you are looking for was not found.
+          {t("notfound.message")}
         </Text>
         <Center zIndex={1}>
           <Link to="/">
@@ -45,7 +47,7 @@ const NotFound = () => {
               mt={4}
               alignSelf="center"
             >
-              Go Back
+              {t("notfound.goBack")}
             </Button>
           </Link>
         </Center>

--- a/frontend/src/components/Common/UserMenu.tsx
+++ b/frontend/src/components/Common/UserMenu.tsx
@@ -5,9 +5,11 @@ import { FiLogOut, FiUser } from "react-icons/fi"
 
 import useAuth from "@/hooks/useAuth"
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "../ui/menu"
+import { useTranslation } from "react-i18next"
 
 const UserMenu = () => {
   const { user, logout } = useAuth()
+  const { t } = useTranslation()
 
   const handleLogout = async () => {
     logout()
@@ -40,7 +42,7 @@ const UserMenu = () => {
                 style={{ cursor: "pointer" }}
               >
                 <FiUser fontSize="18px" />
-                <Box flex="1">My Profile</Box>
+                <Box flex="1">{t("navbar.myProfile")}</Box>
               </MenuItem>
             </Link>
 
@@ -52,7 +54,7 @@ const UserMenu = () => {
               style={{ cursor: "pointer" }}
             >
               <FiLogOut />
-              Log Out
+              {t("navbar.logOut")}
             </MenuItem>
           </MenuContent>
         </MenuRoot>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,25 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import en from "./locales/en.json";
+import de from "./locales/de.json";
+import ja from "./locales/ja.json";
+
+const resources = {
+  en: { translation: en },
+  de: { translation: de },
+  ja: { translation: ja },
+};
+
+const storedLang = localStorage.getItem("language") || "en";
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: storedLang,
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,0 +1,33 @@
+{
+  "language": {
+    "english": "Englisch",
+    "german": "Deutsch",
+    "japanese": "Japanisch"
+  },
+  "login": {
+    "emailPlaceholder": "E-Mail",
+    "passwordPlaceholder": "Passwort",
+    "forgotPassword": "Passwort vergessen?",
+    "loginButton": "Einloggen",
+    "signupPrompt": "Noch kein Konto?",
+    "signupLink": "Registrieren"
+  },
+  "signup": {
+    "fullNamePlaceholder": "Vollständiger Name",
+    "emailPlaceholder": "E-Mail",
+    "passwordPlaceholder": "Passwort",
+    "confirmPasswordPlaceholder": "Passwort bestätigen",
+    "signupButton": "Registrieren",
+    "loginPrompt": "Schon ein Konto?",
+    "loginLink": "Einloggen"
+  },
+  "notfound": {
+    "oops": "Hoppla!",
+    "message": "Die gesuchte Seite wurde nicht gefunden.",
+    "goBack": "Zurück"
+  },
+  "navbar": {
+    "myProfile": "Mein Profil",
+    "logOut": "Ausloggen"
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,33 @@
+{
+  "language": {
+    "english": "English",
+    "german": "Deutsch",
+    "japanese": "日本語"
+  },
+  "login": {
+    "emailPlaceholder": "Email",
+    "passwordPlaceholder": "Password",
+    "forgotPassword": "Forgot Password?!",
+    "loginButton": "Log In",
+    "signupPrompt": "Don't have an account?",
+    "signupLink": "Sign Up"
+  },
+  "signup": {
+    "fullNamePlaceholder": "Full Name",
+    "emailPlaceholder": "Email",
+    "passwordPlaceholder": "Password",
+    "confirmPasswordPlaceholder": "Confirm Password",
+    "signupButton": "Sign Up",
+    "loginPrompt": "Already have an account?",
+    "loginLink": "Log In"
+  },
+  "notfound": {
+    "oops": "Oops!",
+    "message": "The page you are looking for was not found.",
+    "goBack": "Go Back"
+  },
+  "navbar": {
+    "myProfile": "My Profile",
+    "logOut": "Log Out"
+  }
+}

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1,0 +1,33 @@
+{
+  "language": {
+    "english": "英語",
+    "german": "ドイツ語",
+    "japanese": "日本語"
+  },
+  "login": {
+    "emailPlaceholder": "メールアドレス",
+    "passwordPlaceholder": "パスワード",
+    "forgotPassword": "パスワードをお忘れですか？",
+    "loginButton": "ログイン",
+    "signupPrompt": "アカウントをお持ちでない方",
+    "signupLink": "サインアップ"
+  },
+  "signup": {
+    "fullNamePlaceholder": "氏名",
+    "emailPlaceholder": "メールアドレス",
+    "passwordPlaceholder": "パスワード",
+    "confirmPasswordPlaceholder": "パスワード確認",
+    "signupButton": "サインアップ",
+    "loginPrompt": "すでにアカウントをお持ちですか？",
+    "loginLink": "ログイン"
+  },
+  "notfound": {
+    "oops": "おっと！",
+    "message": "お探しのページは見つかりませんでした。",
+    "goBack": "戻る"
+  },
+  "navbar": {
+    "myProfile": "プロフィール",
+    "logOut": "ログアウト"
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { RouterProvider, createRouter } from "@tanstack/react-router"
 import React, { StrictMode } from "react"
+import "./i18n"
 import ReactDOM from "react-dom/client"
 import { routeTree } from "./routeTree.gen"
 

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,4 +1,5 @@
 import { Container, Image, Input, Text } from "@chakra-ui/react"
+import { useTranslation } from "react-i18next"
 import {
   Link as RouterLink,
   createFileRoute,
@@ -29,6 +30,7 @@ export const Route = createFileRoute("/login")({
 
 function Login() {
   const { loginMutation, error, resetError } = useAuth()
+  const { t } = useTranslation()
   const {
     register,
     handleSubmit,
@@ -85,7 +87,7 @@ function Login() {
                 required: "Username is required",
                 pattern: emailPattern,
               })}
-              placeholder="Email"
+              placeholder={t("login.emailPlaceholder")}
               type="email"
             />
           </InputGroup>
@@ -94,19 +96,19 @@ function Login() {
           type="password"
           startElement={<FiLock />}
           {...register("password", passwordRules())}
-          placeholder="Password"
+          placeholder={t("login.passwordPlaceholder")}
           errors={errors}
         />
         <RouterLink to="/recover-password" className="main-link">
-          Forgot Password?!
+          {t("login.forgotPassword")}
         </RouterLink>
         <Button variant="solid" type="submit" loading={isSubmitting} size="md">
-          Log In
+          {t("login.loginButton")}
         </Button>
         <Text>
-          Don't have an account?{" "}
+          {t("login.signupPrompt")} {" "}
           <RouterLink to="/signup" className="main-link">
-            Sign Up
+            {t("login.signupLink")}
           </RouterLink>
         </Text>
       </Container>

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -1,4 +1,5 @@
 import { Container, Flex, Image, Input, Text } from "@chakra-ui/react"
+import { useTranslation } from "react-i18next"
 import {
   Link as RouterLink,
   createFileRoute,
@@ -33,6 +34,7 @@ interface UserRegisterForm extends UserRegister {
 
 function SignUp() {
   const { signUpMutation } = useAuth()
+  const { t } = useTranslation()
   const {
     register,
     handleSubmit,
@@ -85,7 +87,7 @@ function SignUp() {
                 {...register("full_name", {
                   required: "Full Name is required",
                 })}
-                placeholder="Full Name"
+                placeholder={t("signup.fullNamePlaceholder")}
                 type="text"
               />
             </InputGroup>
@@ -99,7 +101,7 @@ function SignUp() {
                   required: "Email is required",
                   pattern: emailPattern,
                 })}
-                placeholder="Email"
+                placeholder={t("signup.emailPlaceholder")}
                 type="email"
               />
             </InputGroup>
@@ -108,23 +110,23 @@ function SignUp() {
             type="password"
             startElement={<FiLock />}
             {...register("password", passwordRules())}
-            placeholder="Password"
+            placeholder={t("signup.passwordPlaceholder")}
             errors={errors}
           />
           <PasswordInput
             type="confirm_password"
             startElement={<FiLock />}
             {...register("confirm_password", confirmPasswordRules(getValues))}
-            placeholder="Confirm Password"
+            placeholder={t("signup.confirmPasswordPlaceholder")}
             errors={errors}
           />
           <Button variant="solid" type="submit" loading={isSubmitting}>
-            Sign Up
+            {t("signup.signupButton")}
           </Button>
           <Text>
-            Already have an account?{" "}
+            {t("signup.loginPrompt")} {" "}
             <RouterLink to="/login" className="main-link">
-              Log In
+              {t("signup.loginLink")}
             </RouterLink>
           </Text>
         </Container>


### PR DESCRIPTION
## Summary
- add i18next and react-i18next dependencies
- initialize i18n with English, German and Japanese locales
- create language switcher component
- translate login, signup, not-found, and menu labels

## Testing
- `npm run lint` *(fails: biome not found)*
- `pytest` *(fails: fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b820f8e74832a8154be7d97120977