### PR TITLE
Add help page to frontend

### DIFF
--- a/frontend/src/components/Common/SidebarItems.tsx
+++ b/frontend/src/components/Common/SidebarItems.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Icon, Text } from "@chakra-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link as RouterLink } from "@tanstack/react-router"
-import { FiBriefcase, FiHome, FiSettings, FiUsers } from "react-icons/fi"
+import { FiBriefcase, FiHome, FiSettings, FiUsers, FiHelpCircle } from "react-icons/fi"
 import type { IconType } from "react-icons/lib"
 
 import type { UserPublic } from "@/client"
@@ -10,6 +10,7 @@ const items = [
   { icon: FiHome, title: "Dashboard", path: "/" },
   { icon: FiBriefcase, title: "Contacts", path: "/contacts" },
   { icon: FiSettings, title: "User Settings", path: "/settings" },
+  { icon: FiHelpCircle, title: "Help", path: "/help" },
 ]
 
 interface SidebarItemsProps {

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as LayoutIndexImport } from './routes/_layout/index'
 import { Route as LayoutSettingsImport } from './routes/_layout/settings'
 import { Route as LayoutContactsImport } from './routes/_layout/contacts'
 import { Route as LayoutAdminImport } from './routes/_layout/admin'
+import { Route as LayoutHelpImport } from './routes/_layout/help'
 
 // Create/Update Routes
 
@@ -68,6 +69,11 @@ const LayoutAdminRoute = LayoutAdminImport.update({
   getParentRoute: () => LayoutRoute,
 } as any)
 
+const LayoutHelpRoute = LayoutHelpImport.update({
+  path: '/help',
+  getParentRoute: () => LayoutRoute,
+} as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -104,6 +110,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutSettingsImport
       parentRoute: typeof LayoutImport
     }
+    '/_layout/help': {
+      preLoaderRoute: typeof LayoutHelpImport
+      parentRoute: typeof LayoutImport
+    }
     '/_layout/': {
       preLoaderRoute: typeof LayoutIndexImport
       parentRoute: typeof LayoutImport
@@ -118,6 +128,7 @@ export const routeTree = rootRoute.addChildren([
     LayoutAdminRoute,
     LayoutContactsRoute,
     LayoutSettingsRoute,
+    LayoutHelpRoute,
     LayoutIndexRoute,
   ]),
   LoginRoute,

--- a/frontend/src/routes/_layout/help.tsx
+++ b/frontend/src/routes/_layout/help.tsx
@@ -1,0 +1,31 @@
+import { Box, Container, Heading, ListItem, UnorderedList, Text } from "@chakra-ui/react"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/_layout/help")({
+  component: Help,
+})
+
+function Help() {
+  return (
+    <Container maxW="full">
+      <Heading size="lg" pt={12} pb={4}>Help</Heading>
+      <Text mb={4}>
+        This application lets you manage contacts and users. Use the menu on the left to navigate between sections.
+      </Text>
+      <Heading size="md" mt={4} mb={2}>Key Features</Heading>
+      <UnorderedList pl={4} mb={4}>
+        <ListItem>Contact management with organisation and description fields.</ListItem>
+        <ListItem>User authentication and authorization with JWT.</ListItem>
+        <ListItem>Responsive UI with dark mode support.</ListItem>
+      </UnorderedList>
+      <Heading size="md" mt={4} mb={2}>Getting Started</Heading>
+      <UnorderedList pl={4}>
+        <ListItem>Log in with your credentials or sign up for a new account.</ListItem>
+        <ListItem>Add new contacts from the Contacts page.</ListItem>
+        <ListItem>Update your profile in User Settings.</ListItem>
+      </UnorderedList>
+    </Container>
+  )
+}
+
+export default Help


### PR DESCRIPTION
## Summary
- add a simple Help page
- show Help link in the sidebar
- update router tree with the new route

## Testing
- `npm run lint` *(fails: biome not found)*
- `docker compose run --rm playwright npx playwright test --reporter=line` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d62f136c0832a8b3e9359f8846bdc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Help" page accessible from the sidebar, providing an overview of key features and getting started instructions.
  * Introduced a new sidebar menu item labeled "Help" with an associated icon for easy navigation to the help page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->